### PR TITLE
Fix vpn test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ ENV PKG_NAME=${PKG_NAME}
 
 ENV PATH="/opt/conda/envs/py310/bin/:${PATH}"
 
+
+EXPOSE 8888
+LABEL p8888="port8"
+
+EXPOSE 5555
+LABEL p5555="port5"
+
 # install federated algorithm
 COPY . /app
 
@@ -18,11 +25,6 @@ RUN conda create -n py310 python=3.10
 RUN pip install /app
 
 
-EXPOSE 8888
-LABEL p8888="port8"
-
-EXPOSE 5555
-LABEL p5555="port5"
 
 # Tell docker to execute `docker_wrapper()` when the image is run.
 CMD python -c "from vantage6.algorithm.tools.wrap import wrap_algorithm; wrap_algorithm()"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # basic python3 image as base
-FROM continuumio/miniconda3:22.11.1-alpine
+FROM continuumio/miniconda3
 
 # This is a placeholder that should be overloaded by invoking
 # docker build with '--build-arg PKG_NAME=...'
@@ -18,7 +18,10 @@ LABEL p5555="port5"
 # install federated algorithm
 COPY . /app
 
-RUN apk add libssl1.1
+RUN apt update
+
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+RUN dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
 
 RUN conda create -n py310 python=3.10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
 # basic python3 image as base
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:22.11.1-alpine
 
 # This is a placeholder that should be overloaded by invoking
 # docker build with '--build-arg PKG_NAME=...'
 ARG PKG_NAME="v6_diagnostics"
 ENV PKG_NAME=${PKG_NAME}
 
-RUN apt update && apt install -y iproute2 traceroute iputils-ping curl
+ENV PATH="/opt/conda/envs/py310/bin/:${PATH}"
 
 # install federated algorithm
 COPY . /app
+
+RUN apk add libssl1.1
+
+RUN conda create -n py310 python=3.10
+
 RUN pip install /app
 
 


### PR DESCRIPTION
Closes #6 

I think the main reason the test failed was because this algorihtm actually exposes 2 ports, but the echo server only listens to 1 of them. When`client.request("vpn/algorithm/addresses", params={ "only_children": True })['addresses']` was called, only half of these addresses pointed to an echo server.

There are more issues with retrieving these algorithm adresses. `client.vpn.get_addresses` and `client.vpn.get_children` don't filter on subtask, but on parent task. Because the parent task is being run on every node, multiple subtasks are created. The algorithm then retrieves not only addresses of subtasks that was triggered by it, but also subtasks triggered by its sibling. See https://github.com/vantage6/vantage6/issues/1319 .

I found a workaround for this but the api needs to be changed as well.